### PR TITLE
Fix: Dark mode preview popup text visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -665,6 +665,16 @@ body {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+/* Dark mode preview modal */
+.dark .preview-modal {
+    background: var(--bg-secondary) !important;
+}
+
+.dark .preview-modal .prose {
+    color: var(--text-primary) !important;
+    background: var(--bg-tertiary) !important;
+}
+
 @media (max-width: 480px) {
     .gem-card {
         min-height: 300px;

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
              x-transition:leave="transition ease-in duration-200"
              x-transition:leave-start="opacity-100 transform scale-100"
              x-transition:leave-end="opacity-0 transform scale-95"
-             class="bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
+             class="preview-modal bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
 
             <!-- Modal Header -->
             <div class="bg-gradient-to-r from-indigo-600 to-purple-600 text-white p-6">


### PR DESCRIPTION
The text in the dark mode preview popup was not visible because the background was light and the text was light. This commit fixes the issue by adding a custom class to the preview modal and adding specific styles for it in dark mode.